### PR TITLE
Loosen dependency restriction by allowing Bolts newer than 1.1.0

### DIFF
--- a/Gini-iOS-SDK/0.2.5/Gini-iOS-SDK.podspec
+++ b/Gini-iOS-SDK/0.2.5/Gini-iOS-SDK.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name     = 'Gini-iOS-SDK'
+  s.version  = '0.2.5'
+  s.license  = 'MIT'
+  s.summary  = 'An SDK for integrating the magical Gini technology into other apps.'
+  s.homepage = 'https://github.com/gini/gini-sdk-ios'
+  s.social_media_url = 'https://twitter.com/gini'
+  s.authors  = { 'Gini GmbH' => 'info@gini.net' }
+  s.source   = { :git => 'https://github.com/gini/gini-sdk-ios.git', :tag => s.version.to_s }
+  s.documentation_url = 'http://developer.gini.net/gini-sdk-ios/'
+  s.requires_arc = true
+  s.platform     = :ios, "7.0"
+  s.public_header_files = 'Gini-iOS-SDK/**/*.h'
+  s.source_files = 'Gini-iOS-SDK'
+  s.dependency "Bolts", "~> 1.1.0"
+end


### PR DESCRIPTION
This should fix the following problem:

19:21:22 + pod update
19:21:23 Update all pods
19:21:23 Analyzing dependencies

19:21:51 Downloading dependencies
19:21:51 Installing Bolts (1.1.0)

19:21:52 [!] /usr/bin/git fetch origin tags/v1.1.0 2>&1
19:21:52 
19:21:52 fatal: Couldn't find remote ref tags/v1.1.0
19:21:52 
19:21:52 fatal: The remote end hung up unexpectedly
19:21:52 Build step 'Execute shell' marked build as failure
